### PR TITLE
fix: Date 생성 일자 기준 로직 수정

### DIFF
--- a/src/main/java/com/tilguys/matilda/til/service/TilService.java
+++ b/src/main/java/com/tilguys/matilda/til/service/TilService.java
@@ -54,7 +54,7 @@ public class TilService {
     public TilDatesResponse getAllTilDatesByUserId(final Long userId) {
         List<LocalDate> all = tilRepository.findByUserId(userId)
                 .stream()
-                .map(til -> til.getCreatedAt().toLocalDate())
+                .map(Til::getDate)
                 .toList();
 
         return new TilDatesResponse(all);


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #44 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

TIL 히스토리 화면에 기록된 날짜에 따로 표시하는 기능이었습니다.
하지만, 생성 일자 기준으로 받아와 수정 과정에서 작성일자를 바꾸어도 표시가 안되는 버그를 수정했습니다.
