### PR TITLE
fix: 삭제된 til에 대한 '같은 날 중복 생성 방지' 처리 수정

### DIFF
--- a/src/main/java/com/tilguys/matilda/til/repository/TilRepository.java
+++ b/src/main/java/com/tilguys/matilda/til/repository/TilRepository.java
@@ -1,14 +1,14 @@
 package com.tilguys.matilda.til.repository;
 
 import com.tilguys.matilda.til.domain.Til;
-import java.time.LocalDate;
-import java.util.List;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Repository
 public interface TilRepository extends JpaRepository<Til, Long> {
@@ -20,6 +20,5 @@ public interface TilRepository extends JpaRepository<Til, Long> {
     @Query(value = "SELECT t FROM Til t WHERE t.isDeleted = false AND t.isPublic = true ORDER BY t.createdAt DESC LIMIT 10")
     List<Til> findRecentPublicTils();
 
-    @Query(value = "SELECT CASE WHEN COUNT(t) > 0 THEN true ELSE false END FROM Til t WHERE t.isDeleted = false AND t.date = :date AND t.userId = :userId")
-    boolean existsByDateAndUserId(@Param("date") LocalDate date, @Param("userId") Long userId);
+    boolean existsByDateAndUserIdAndIsDeletedFalse(LocalDate date, Long userId);
 }

--- a/src/main/java/com/tilguys/matilda/til/service/TilService.java
+++ b/src/main/java/com/tilguys/matilda/til/service/TilService.java
@@ -9,8 +9,6 @@ import com.tilguys.matilda.til.dto.TilDetailResponse;
 import com.tilguys.matilda.til.dto.TilDetailsResponse;
 import com.tilguys.matilda.til.dto.TilUpdateRequest;
 import com.tilguys.matilda.til.repository.TilRepository;
-import java.time.LocalDate;
-import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -18,6 +16,9 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDate;
+import java.util.List;
 
 @Service
 @Transactional
@@ -31,7 +32,7 @@ public class TilService {
 
     @Transactional
     public Til createTil(final TilCreateRequest tilCreateDto, final long userId) {
-        boolean exists = tilRepository.existsByDateAndUserId(tilCreateDto.date(), userId);
+        boolean exists = tilRepository.existsByDateAndUserIdAndIsDeletedFalse(tilCreateDto.date(), userId);
         if (exists) {
             throw new IllegalArgumentException("같은 날에 작성된 게시물이 존재합니다!");
         }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#67 

## 🔘 Part

- [x] 삭제된 til에 대한 '같은 날 중복 생성 방지' 처리 수정

## 🔎 작업 내용

- 기능에서 어떤 부분이 구현되었는지 설명해주세요

close #67 