### PR TITLE
[Refactor]: 회원가입시 닉네임이 비어있으면 아이디를 닉네임으로 사용하도록 수정

### DIFF
--- a/src/main/java/com/tilguys/matilda/common/auth/service/AuthService.java
+++ b/src/main/java/com/tilguys/matilda/common/auth/service/AuthService.java
@@ -20,12 +20,12 @@ public class AuthService {
 
     private final UserService userService;
 
-    public void signup(String identifier) {
-        userService.signup(identifier);
+    public void signup(String identifier, String nickname) {
+        userService.signup(identifier, nickname);
     }
 
     public void loginProcessByGithubInfo(GithubUserInfo gitHubUserInfo) {
-        signup(gitHubUserInfo.identifier());
+        signup(gitHubUserInfo.identifier(), gitHubUserInfo.nickname());
         updateUserProfile(gitHubUserInfo);
 
         TilUser userByIdentifier = userService.findUserByIdentifier(gitHubUserInfo.identifier())

--- a/src/main/java/com/tilguys/matilda/common/auth/service/UserService.java
+++ b/src/main/java/com/tilguys/matilda/common/auth/service/UserService.java
@@ -27,12 +27,16 @@ public class UserService {
         return userRepository.findByIdentifier(userIdentifier);
     }
 
-    public void signup(String identifier) {
+    public void signup(String identifier, String nickname) {
+        if (nickname == null) {
+            nickname = identifier;
+        }
         if (userRepository.existsByIdentifier(identifier)) {
             return;
         }
         TilUser tilUser = TilUser.builder()
                 .identifier(identifier)
+                .nickname(nickname)
                 .providerInfo(ProviderInfo.GITHUB)
                 .role(Role.USER)
                 .build();


### PR DESCRIPTION
## #️⃣ 연관된 이슈

#103

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 회원가입시 닉네임이 비어있으면 아이디를 닉네임으로 사용하도록 수정


