### PR TITLE
[Feat] 소셜 미디어 공유 시 미리보기 기능 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -44,6 +44,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.boot:spring-boot-starter-thymeleaf'
 
     implementation group: 'io.jsonwebtoken', name: 'jjwt-api', version: '0.11.2'
     implementation group: 'io.jsonwebtoken', name: 'jjwt-impl', version: '0.11.2'

--- a/src/main/java/com/tilguys/matilda/common/auth/config/SecurityConfig.java
+++ b/src/main/java/com/tilguys/matilda/common/auth/config/SecurityConfig.java
@@ -71,6 +71,7 @@ public class SecurityConfig implements WebMvcConfigurer {
                 .addFilterBefore(prevLoginFilter(), UsernamePasswordAuthenticationFilter.class)
                 .authorizeHttpRequests(request -> request
                         .requestMatchers(HttpMethod.GET, "/api/til/**").permitAll()
+                        .requestMatchers(HttpMethod.GET, "/share/**").permitAll()
                         .requestMatchers(
                                 "/api/oauth/login",
                                 "/api/oauth/logout",

--- a/src/main/java/com/tilguys/matilda/til/controller/TilShareController.java
+++ b/src/main/java/com/tilguys/matilda/til/controller/TilShareController.java
@@ -1,0 +1,74 @@
+package com.tilguys.matilda.til.controller;
+
+import com.tilguys.matilda.til.domain.Til;
+import com.tilguys.matilda.til.dto.TilWithUserResponse;
+import com.tilguys.matilda.til.service.TilService;
+import jakarta.servlet.http.HttpServletRequest;
+import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@RequestMapping("/share")
+@Controller
+@RequiredArgsConstructor
+public class TilShareController {
+
+    private final TilService tilService;
+
+    @Value("${frontend.url}")
+    private String frontendUrl;
+
+    @GetMapping("/{id}")
+    public String shareTil(@PathVariable Long id,
+                           HttpServletRequest request,
+                           Model model) {
+
+        String userAgent = request.getHeader("User-Agent");
+
+        if (isSocialMediaBot(userAgent)) {
+            Til til = tilService.getTilByTilId(id);
+            TilWithUserResponse response = new TilWithUserResponse(til);
+
+            model.addAttribute("til", response);
+            model.addAttribute("frontendUrl", frontendUrl);
+            model.addAttribute("description", createDescription(response.content()));
+            model.addAttribute("imageUrl", getImageUrl());
+
+            return "share/og-template";
+        } else {
+            return "redirect:" + frontendUrl + "/all-tils?tilId=" + id;
+        }
+    }
+
+    private boolean isSocialMediaBot(String userAgent) {
+        if (userAgent == null) {
+            return false;
+        }
+
+        String[] botPatterns = {
+                "kakaotalk",
+                "slackbot",
+                "discordbot",
+                "linkedinbot"
+        };
+
+        String lowerUserAgent = userAgent.toLowerCase();
+        return Arrays.stream(botPatterns)
+                .anyMatch(lowerUserAgent::contains);
+    }
+
+    private String createDescription(String content) {
+        return content.length() > 150
+                ? content.substring(0, 150) + "..."
+                : content;
+    }
+
+    private String getImageUrl() {
+        return frontendUrl + "/assets/matilda-default-og.png";
+    }
+}

--- a/src/main/resources/templates/share/og-template.html
+++ b/src/main/resources/templates/share/og-template.html
@@ -1,0 +1,178 @@
+<!-- src/main/resources/templates/share/og-template.html -->
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+
+    <!-- Open Graph Meta Tags -->
+    <meta property="og:title" th:content="${til.title}"/>
+    <meta property="og:description" th:content="${description}"/>
+    <meta property="og:image" th:content="${imageUrl}"/>
+    <meta property="og:url" th:content="@{/share/{tilId}(tilId=${til.id})}"/>
+    <meta property="og:type" content="article"/>
+    <meta property="og:site_name" content="마틸다 TIL"/>
+
+    <!-- 기본 메타 태그 -->
+    <meta name="description" th:content="${description}"/>
+    <title th:text="${til.title} + ' - 마틸다 TIL'"></title>
+
+    <!-- 스타일링 -->
+    <style>
+        body {
+            font-family: 'Noto Sans KR', -apple-system, BlinkMacSystemFont, sans-serif;
+            background: linear-gradient(135deg, #6A5ACD 0%, #5F9EA0 100%);
+            margin: 0;
+            padding: 0;
+            min-height: 100vh;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+        }
+
+        .container {
+            background: white;
+            border-radius: 16px;
+            padding: 40px;
+            box-shadow: 0 8px 32px rgba(0, 0, 0, 0.1);
+            text-align: center;
+            max-width: 700px;
+            margin: 20px;
+        }
+
+        .logo {
+            font-size: 2.5rem;
+            margin-bottom: 1rem;
+        }
+
+        .author-info {
+            color: #6A5ACD;
+            font-size: 1.1rem;
+            font-weight: 500;
+            margin-bottom: 0.5rem;
+        }
+
+        .date-info {
+            color: #5F9EA0;
+            font-size: 1.3rem;
+            font-weight: 600;
+            margin-bottom: 1.5rem;
+        }
+
+        .content-preview {
+            color: #666;
+            font-size: 1rem;
+            line-height: 1.6;
+            margin-bottom: 1.5rem;
+            padding: 20px;
+            background-color: #f8f9fa;
+            border-radius: 8px;
+            white-space: pre-line;
+        }
+
+        .tags {
+            margin-bottom: 1.5rem;
+        }
+
+        .tags-title {
+            color: #666;
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .tag {
+            display: inline-block;
+            background: #B39DDB;
+            color: white;
+            padding: 4px 12px;
+            border-radius: 20px;
+            font-size: 0.8rem;
+            margin: 2px;
+        }
+
+        .references {
+            margin-bottom: 2rem;
+        }
+
+        .references-title {
+            color: #666;
+            font-size: 0.9rem;
+            margin-bottom: 0.5rem;
+        }
+
+        .reference-word {
+            display: inline-block;
+            background: #81DEEA;
+            color: white;
+            padding: 4px 10px;
+            border-radius: 15px;
+            font-size: 0.8rem;
+            margin: 2px;
+        }
+
+        .redirect-info {
+            color: #999;
+            font-size: 0.9rem;
+            margin-bottom: 1rem;
+        }
+
+        .loading {
+            display: inline-block;
+            width: 20px;
+            height: 20px;
+            border: 2px solid #f3f3f3;
+            border-top: 2px solid #6A5ACD;
+            border-radius: 50%;
+            animation: spin 1s linear infinite;
+            margin-right: 8px;
+        }
+
+        @keyframes spin {
+            0% { transform: rotate(0deg); }
+            100% { transform: rotate(360deg); }
+        }
+    </style>
+</head>
+<body>
+<div class="container">
+    <div class="logo">✏️</div>
+
+    <!-- 작성자 정보 -->
+    <div class="author-info">
+        <span>작성자: </span>
+        <strong th:text="${til.nickname}">작성자명</strong>
+    </div>
+
+    <!-- 날짜 (제목) -->
+    <div class="date-info" th:text="${til.title}">날짜</div>
+
+    <!-- 내용 미리보기 -->
+    <div class="content-preview" th:text="${description}">TIL 내용 미리보기</div>
+
+    <!-- 태그 목록 -->
+    <div class="tags" th:if="${til.tags != null and #lists.size(til.tags.tags) > 0}">
+        <div class="tags-title">🏷️ 태그</div>
+        <span class="tag" th:each="tag : ${til.tags.tags}" th:text="'#' + ${tag}"></span>
+    </div>
+
+    <!-- 학습 단어 (References) -->
+    <div class="references" th:if="${til.references != null and #lists.size(til.references.words) > 0}">
+        <div class="references-title">📚 학습 단어</div>
+        <span class="reference-word" th:each="word : ${til.references.words}" th:text="${word}"></span>
+    </div>
+
+    <div class="redirect-info">
+        <div class="loading"></div>
+        TIL 페이지로 이동 중...
+    </div>
+
+    <script th:inline="javascript">
+        /*<![CDATA[*/
+        setTimeout(function () {
+            window.location.href = /*[[${frontendUrl}]]*/ + '/all-tils?tilId=' + /*[[${til.id}]]*/ ;
+        }, 2000);
+        /*]]>*/
+    </script>
+</div>
+</body>
+</html>


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #130


## 🔘 Part

- [x] BE

## 🔎 작업 내용

### 🎯 **문제 상황**
현재 TIL 링크를 슬랙/카카오톡/디스코드에 공유하면 **URL만 표시**되고 예쁜 미리보기가 나오지 않음

**현재:**
```
https://matilda.com/all-tils?tilId=123
```

**원하는 결과:**
```
┌─────────────────────────────────────┐
│ 📝 3월 27일 수요일 - 마틸다 TIL      │
│                                     │
│ React Hook 학습 내용...             │
│ 🏷️ #React #Hook                    │
│ 📚 useState, useEffect              │
│ [썸네일 이미지]                      │
└─────────────────────────────────────┘
```

## ❌ **현재 React 환경에서 안 되는 이유**

#### 1. **소셜 미디어 봇은 JavaScript를 실행하지 않음**
```javascript
// React 앱 구조
<div id="root"></div>
<script src="bundle.js"></script>
```

**슬랙봇이 보는 것:**
- 빈 div 태그만 존재
- JavaScript 실행 안 함 → 컴포넌트 렌더링 안 됨
- 메타태그 없음 → 미리보기 불가

#### 2. **Open Graph 메타태그가 HTML head에 없음**
소셜 미디어 미리보기에 필요한 태그들:
```html
<meta property="og:title" content="TIL 제목" />
<meta property="og:description" content="TIL 내용" />
<meta property="og:image" content="썸네일 URL" />
```

**React SPA에서는:** 이런 메타태그가 런타임에 동적 생성되지만, 봇은 초기 HTML만 읽음

#### 3. **서버사이드 렌더링 필요**
- 봇이 방문할 때 이미 완성된 HTML이 있어야 함
- React는 클라이언트사이드 렌더링 → 봇이 내용을 못 봄


### 💡 **해결 방법**
Spring MVC로 **Open Graph** 전용 페이지 생성

#### 동작 원리:
1. **봇 요청** → HTML + 메타태그 반환 (미리보기용)
2. **사용자 요청** → React 앱으로 리다이렉트

### 🛠 **구현 내용**

### 1. 컨트롤러 추가
```java
@RequestMapping("/share")
@Controller
public class TilShareController {
    @GetMapping("/{id}")
    public String shareTil(@PathVariable Long id, HttpServletRequest request) {
        if (isSocialMediaBot(request.getHeader("User-Agent"))) {
            // 봇이면 HTML 템플릿 반환
            return "share/og-template";
        } else {
            // 사용자면 React 앱으로 리다이렉트
            return "redirect:" + frontendUrl + "/all-tils?tilId=" + id;
        }
    }
}
```

#### 2. Thymeleaf 템플릿 생성
- 경로: `src/main/resources/templates/share/og-template.html`
- Open Graph 메타태그 + 예쁜 로딩 페이지

#### 3. 공유 버튼 추가 (React)
```jsx
const shareUrl = `${API_BASE_URL}/share/${tilId}`
// 사용자가 복사해서 슬랙/카톡에 공유
```

### 📊 **예상 효과**
- ✅ 슬랙/카카오톡/디스코드에서 예쁜 미리보기
- ✅ 기존 React 앱 구조 유지


## 🔔 기타
초기 리액트가 가진 문제로, SSR이 가능한 next.js 부터 S3,Netlify,Cloudflare Pages 정적 html 배포 등을 고려했었음.
가장 간단하고 효과적인 방법인 Spring Mvc를 깨달아 이를 적용하게됨,,


## 특이사항
- 이거 근데 외부에서 접근해야 출력 결과를 확인 가능함.
- 코드 자체에 문제는 없음을 확인했으나, 배포 서버에서 예상대로 동작하는 지는 검증이 필요함.


Close #130