### PR TITLE
fix: TIL 반환 최대 갯수 제한

### DIFF
--- a/src/main/java/com/tilguys/matilda/til/controller/TilController.java
+++ b/src/main/java/com/tilguys/matilda/til/controller/TilController.java
@@ -11,6 +11,7 @@ import com.tilguys.matilda.til.dto.TilWithUserResponse;
 import com.tilguys.matilda.til.service.RecentTilService;
 import com.tilguys.matilda.til.service.TilService;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -43,7 +44,9 @@ public class TilController {
             @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
             LocalDateTime createdDate,
             @RequestParam(required = false) Long tilId,
-            @RequestParam(defaultValue = "10") int size
+            @RequestParam(defaultValue = "10")
+            @Max(value = 100)
+            int size
     ) {
         return ResponseEntity.ok(tilService.getPublicTils(
                 createdDate, tilId, size)


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #97 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- TIL 최대 계수 제한했습니다.

## 🌄 이미지 첨부 

![스크린샷 2025-06-29 오후 5 45 18](https://github.com/user-attachments/assets/2c123b0d-bf8d-4663-84c0-f66c37ff6e61)

궁금한 점이 있는데, 원래는 `message` 속성에 에러 메시지를 담았습니다. 근데 아래 코드 처럼 Valid 에러 메시지는 기본 예외 메시지로 첨부한 거 같은데 의도한건지 궁금합니다. @wodnd0131 

즉, Error Message 정의 ex : "100 이상 TIL을 반환할 수 없습니다." 설정해도 사진과 같이 기본값이 표현됩니다.

``` java
@ExceptionHandler(MethodArgumentNotValidException.class)
    public ProblemDetail handleValidationException(MethodArgumentNotValidException e) {
        log.warn("Validation failed: {}", e.getMessage());

        List<String> errors = e.getBindingResult()
                .getFieldErrors()
                .stream()
                .map(FieldError::getDefaultMessage)
                .toList();

        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(
                HttpStatus.BAD_REQUEST,
                errors.getFirst()
        );
        problemDetail.setTitle("ValidationException");
        problemDetail.setProperty("timestamp", LocalDateTime.now());
        problemDetail.setProperty("validationErrors", errors);
        return problemDetail;
    }
```