### PR TITLE
build: 코드 커버리지 계산에서 특정 디렉토리(controller, auth, exception) 제외 처리

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -78,4 +78,14 @@ jacocoTestReport {
         xml.required.set(true)
         html.required.set(true)
     }
+
+    afterEvaluate {
+        classDirectories.setFrom(files(classDirectories.files.collect {
+            fileTree(dir: it, exclude: [
+                    "**/controller/**",
+                    "**/auth/**",
+                    "**/exception/**"
+            ])
+        }))
+    }
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈

> #154 

## 🔘 Part

- [x] BE

## 🔎 작업 내용

- 회의한 내용을 바탕으로 Jacoco의 몇몇 탐색 대상을 제외했습니다.

## 🌄 이미지 첨부 

![스크린샷 2025-06-30 오전 2 16 08](https://github.com/user-attachments/assets/1ee8998e-36c7-42b3-938e-6144c66b69f9)
